### PR TITLE
Fix for issue #3: If Tweet text contains only a URL, show the URL

### DIFF
--- a/public/js/src/twelescreen_models.js
+++ b/public/js/src/twelescreen_models.js
@@ -553,8 +553,14 @@ twelescreen.models.tweet_slide = function(spec) {
     // Match URLs:
     var exp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
     var urls = tweet.text.match(exp);
-    // Remove all URLs:
-    var tweet_text = tweet.text.replace(exp, '');
+    // Does the tweet text contain only a URL?
+    if (urls !== null && tweet.text == urls[0]) {
+        // If so, keep it:
+         var tweet_text = tweet.text;
+      } else {
+        // Otherwise remove all URLs:
+        var tweet_text = tweet.text.replace(exp, '');
+    }
     // If there are URL(s), wrap all the text in the first one.
     if (urls !== null) {
       tweet_text = '<a href="' + urls[0] + '">' + tweet_text + '</a>';


### PR DESCRIPTION
The "url" for newer tweets look like "http://t.co/2Wbsm7IIt7", so it may be better one of these: 
          "expanded_url": "http://www.google.com",
          "display_url": "google.com".
