### PR TITLE
Workaround default-theme loading bug

### DIFF
--- a/config/example_basic.yaml
+++ b/config/example_basic.yaml
@@ -4,6 +4,8 @@ twitter:
   access_token_key: yourkeyhere
   access_token_secret: yoursecrethere
 categories:
+  _defaults:
+    theme: default
   news:
     title: News headlines
     screen_names:


### PR DESCRIPTION
If no category theme is specified in the yaml, there's a problem somewhere loading the 'default' theme from the settings. This results in there being no (news/bbcradio) categories shown on the index page, and nothing can be selected, no tweets shown. Also nothing is shown if you go straight to the /news page. Here's a workaround.
