### PR TITLE
Replace t.co links with expanded_url

### DIFF
--- a/app/streamer.js
+++ b/app/streamer.js
@@ -64,6 +64,7 @@ module.exports = function(settings, twitter, io, _) {
    */
   streamer.get_user_ids = function() {
     console.log('Streamer (1/3 start):  Fetching Twitter user IDs');
+
     streamer.twitter.lookupUser(settings.watched_screen_names, function(err, users) {
       if (err) {
         console.log("Streamer: Error fetching user IDs: "+err);
@@ -240,12 +241,12 @@ module.exports = function(settings, twitter, io, _) {
    */
   streamer.shrink_tweet = function(tweet) {
 
-  // Replace t.co URLs with expanded_urls in the tweet text
-  var urls = tweet.entities.urls;
-  var arrayLength = urls.length;
-  for (var i = 0; i < arrayLength; i++) {
-    tweet.text = tweet.text.replace(urls[i]['url'], urls[i]['expanded_url']);
-  }
+    // Replace t.co URLs with expanded_urls in the tweet text
+    var urls = tweet.entities.urls;
+    var arrayLength = urls.length;
+    for (var i = 0; i < arrayLength; i++) {
+      tweet.text = tweet.text.replace(urls[i]['url'], urls[i]['expanded_url']);
+    }
 
     var shrunk = {
       // A subset of the usual data, with the same keys and structure:

--- a/app/streamer.js
+++ b/app/streamer.js
@@ -239,6 +239,14 @@ module.exports = function(settings, twitter, io, _) {
    * tweet is the full array of Tweet data fetched from Twitter.
    */
   streamer.shrink_tweet = function(tweet) {
+
+  // Replace t.co URLs with expanded_urls in the tweet text
+  var urls = tweet.entities.urls;
+  var arrayLength = urls.length;
+  for (var i = 0; i < arrayLength; i++) {
+    tweet.text = tweet.text.replace(urls[i]['url'], urls[i]['expanded_url']);
+  }
+
     var shrunk = {
       // A subset of the usual data, with the same keys and structure:
       id: tweet.id,

--- a/app/streamer.js
+++ b/app/streamer.js
@@ -34,7 +34,7 @@ module.exports = function(settings, twitter, io, _) {
       consumer_key: settings.twitter.consumer_key,
       consumer_secret: settings.twitter.consumer_secret,
       access_token_key: settings.twitter.access_token_key,
-      access_token_secret: settings.twitter.access_token_secret 
+      access_token_secret: settings.twitter.access_token_secret
     });
 
     // These methods are kind of dependent on each other, so we only run them
@@ -57,7 +57,7 @@ module.exports = function(settings, twitter, io, _) {
     };
   };
 
-      
+
   /**
    * Get all the Twitter user IDs from the screen_names we have in config.
    * We need the user IDs, not screen_names, for streaming.
@@ -69,12 +69,12 @@ module.exports = function(settings, twitter, io, _) {
         console.log("Streamer: Error fetching user IDs: "+err);
       } else {
         users.forEach(function(user){
-          settings.watched_ids.push(user.id); 
+          settings.watched_ids.push(user.id);
         });
         // On to the next method...
         console.log('Streamer (1/3 finish): Fetching Twitter user IDs');
         streamer.next_in_queue();
-      }; 
+      };
     });
   };
 
@@ -91,12 +91,12 @@ module.exports = function(settings, twitter, io, _) {
       // Note: The 'count' doesn't include retweets and replies, so we'll
       // probably get less than that many tweets returned.
       streamer.twitter.getUserTimeline({
-        user_id: id, 
+        user_id: id,
         trim_user: false, exclude_replies: true,
         contributor_details: true, include_rts: false, count: 200
       }, function(err, tweets) {
         if (err) {
-          console.log("Streamer: Error fetching tweets for user id '"+id+"': "+err); 
+          console.log("Streamer: Error fetching tweets for user id '"+id+"': "+err);
         } else {
           tweets.forEach(function(tweet){
             streamer.add_tweet_to_cache(tweet);
@@ -122,7 +122,7 @@ module.exports = function(settings, twitter, io, _) {
     console.log('Streamer (3/3 start):      Listening for new Tweets');
     streamer.prepare_for_clients();
 
-    // Tell the twitter API to filter on the watched_ids. 
+    // Tell the twitter API to filter on the watched_ids.
     streamer.twitter.stream(
       'statuses/filter', {follow: settings.watched_ids}, function(stream) {
 
@@ -157,7 +157,7 @@ module.exports = function(settings, twitter, io, _) {
    * We only send them the most recent tweets for their category/room.
    */
   streamer.prepare_for_clients = function() {
-    io.sockets.on('connection', function(client) { 
+    io.sockets.on('connection', function(client) {
       console.log('Connected client:', client.id);
       client.on('subscribe', function(room) {
         if (_.indexOf(settings.valid_categories, room) >= 0) {
@@ -208,7 +208,7 @@ module.exports = function(settings, twitter, io, _) {
    * `tweet` is a full array of data about a tweet.
    */
   streamer.add_tweet_to_cache = function(tweet) {
-    var shrunk_tweet = streamer.shrink_tweet(tweet);  
+    var shrunk_tweet = streamer.shrink_tweet(tweet);
     // We want to ignore any retweets of the the accounts we follow:
     if (tweet.retweeted_status === undefined) {
       // Get all the categories this Tweet's account is in.
@@ -219,7 +219,7 @@ module.exports = function(settings, twitter, io, _) {
         // For each category this twitter account is associated with, add to cache.
         categories.forEach(function(category){
           if (category in streamer.cache) {
-            streamer.cache[category].push(shrunk_tweet); 
+            streamer.cache[category].push(shrunk_tweet);
           } else {
             streamer.cache[category] = [shrunk_tweet];
           };


### PR DESCRIPTION
Closes #7.

If a tweet contains only a URL, it's displayed. But it's an ugly `https://t.co/kYoCZJU6XZ`.

This PR replaces it with the `expanded_url`. `display_url` isn't used because it can be truncated and cannot be used as a real link:
```
  urls: 
   [ { url: 'https://t.co/kYoCZJU6XZ',
       expanded_url: 'http://www.theguardian.com/commentisfree/2015/nov/10/workplace-racism-racial-bullying-discrimination',
       display_url: 'theguardian.com/commentisfree/…',
       indices: [Object] } ] }
```

---

Side-effects:

app/streamer.js doesn't send any entities to the front-end. For tweets that are just URL, `expanded_url` is now used for display and the `href`. For tweets that have more text, all the links are stripped and the first `expanded_url` is used for the `href`. 
https://github.com/philgyford/twelescreen/blob/master/public/js/src/twelescreen_models.js#L553-L568

I suppose in an ideal world we could send the entities, then the front-end can use `url` for the `href` (so Twitter can count stats, I guess), and perhaps even use `display_url` for display. But is that important?