### PR TITLE
Don't let single-URL tweets go off the edge of the screen

### DIFF
--- a/public/css/base.css
+++ b/public/css/base.css
@@ -326,6 +326,7 @@ body {
   }
   .tweet_message_panel-text .tweet_message_panel_inner {
     line-height: 1.2em;
+    max-width: 100%;
   }
   .tweet_message_panel-image .tweet_message_panel_inner {
     line-height: 1px;

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -4,7 +4,7 @@
  * Extend with a theme CSS file, like themes/default/styles.css
  */
 
-/* http://meyerweb.com/eric/tools/css/reset/ 
+/* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
    License: none (public domain)
 */
@@ -17,8 +17,8 @@ b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
   margin: 0;
@@ -29,7 +29,7 @@ time, mark, audio, video {
   vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
+article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
   display: block;
 }
@@ -80,7 +80,7 @@ body {
  */
 .vbox {
   display: -webkit-box; /* OLD: Safari, iOS, Android, older WebKit.  */
-  display: -moz-box;    /* OLD: Firefox (buggy) */ 
+  display: -moz-box;    /* OLD: Firefox (buggy) */
   display: -ms-flexbox; /* MID: IE 10 */
   display: -webkit-flex;/* NEW, Chrome 21–28, Safari 6.1+ */
   display: flex;        /* NEW: IE11, Chrome 29+, Opera 12.1+, Firefox 22+ */
@@ -90,21 +90,21 @@ body {
   -ms-flex-align: center;
   -webkit-align-items: center;
   align-items: center;
-} 
+}
 
 /**
  * A block element inside will be horizontally centered.
  */
 .hbox {
   display: -webkit-box; /* OLD: Safari, iOS, Android, older WebKit.  */
-  display: -moz-box;    /* OLD: Firefox (buggy) */ 
+  display: -moz-box;    /* OLD: Firefox (buggy) */
   display: -ms-flexbox; /* MID: IE 10 */
   display: -webkit-flex;/* NEW, Chrome 21–28, Safari 6.1+ */
   display: flex;        /* NEW: IE11, Chrome 29+, Opera 12.1+, Firefox 22+ */
 
   -webkit-box-pack: center;
-  -moz-box-pack: center; 
-  -ms-flex-pack: center; 
+  -moz-box-pack: center;
+  -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
 }
@@ -137,7 +137,7 @@ body {
  * .menu-body     70%
  * .menu-outro    10%
  * .menu-footer    5%
- * 
+ *
  */
 
 .menu_header {
@@ -153,7 +153,7 @@ body {
   }
 }
   .menu_header_inner {
-    padding: 0.2em 10%; 
+    padding: 0.2em 10%;
   }
 
 .menu_body {
@@ -178,7 +178,7 @@ body {
 
     .categories {
       width: 100%;
-      margin: 0 auto; 
+      margin: 0 auto;
     }
       .category {
         margin: 0.5em 2%;
@@ -219,7 +219,7 @@ body {
   text-align: center;
   font-size: 1.2em;
   line-height: 1.4em;
-} 
+}
   .menu_footer_inner {
     width: 90%;
     margin: 0 auto;
@@ -304,7 +304,7 @@ body {
     top: 0;
     right: 3%;
     width: 1.4em;
-  } 
+  }
   .tweet_account_name {
     width: 80%;
     height: 10%;


### PR DESCRIPTION
Single-URL tweets don't fit on the screen:

![image](https://cloud.githubusercontent.com/assets/1324225/11323014/98f36754-910d-11e5-8712-68c24ee34da0.png)

Here's a little CSS tweak to make sure they don't get too big:

![image](https://cloud.githubusercontent.com/assets/1324225/11323018/c8009b34-910d-11e5-89e7-4fe775e69ec8.png)
