### PR TITLE
Replace \n with <br>

### DIFF
--- a/app/streamer.js
+++ b/app/streamer.js
@@ -242,7 +242,7 @@ module.exports = function(settings, twitter, io, _) {
     var shrunk = {
       // A subset of the usual data, with the same keys and structure:
       id: tweet.id,
-      text: tweet.text,
+      text: tweet.text.replace(/\n/g, '<br>'),
       user: {
         id: tweet.user.id,
         name: tweet.user.name,


### PR DESCRIPTION
Sometimes tweets contain newlines, which of course don't show up in HTML.